### PR TITLE
MEDIAWIKI-97: Some descriptions have type/grammar mistakes

### DIFF
--- a/mediawiki-syntax/src/main/java/org/xwiki/contrib/mediawiki/syntax/MediaWikiSyntaxInputProperties.java
+++ b/mediawiki-syntax/src/main/java/org/xwiki/contrib/mediawiki/syntax/MediaWikiSyntaxInputProperties.java
@@ -154,7 +154,7 @@ public class MediaWikiSyntaxInputProperties extends DefaultFilterStreamPropertie
      * @since 1.8
      */
     @PropertyName("No table of content")
-    @PropertyDescription("Disable automaticlaly generated tables of content (unless _TOC_ is explicitely used)")
+    @PropertyDescription("Disable automatically generated tables of content (unless _TOC_ is explicitely used)")
     public boolean isNoToc()
     {
         return this.noToc;

--- a/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
+++ b/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
@@ -154,7 +154,7 @@ public class MediaWikiInputProperties extends XMLInputProperties
      */
     @PropertyName("Files space")
     @PropertyDescription("The space where to store the files."
-        + "By default the namespace definded in the MediaWiki (usually \"File\").")
+        + " By default the namespace defined in the MediaWiki (usually \"File\").")
     public EntityReference getFileSpace()
     {
         return this.fileSpace;
@@ -226,7 +226,7 @@ public class MediaWikiInputProperties extends XMLInputProperties
      * @return if true, final pages will be produces (only if #isConvertToXWiki() is true)
      */
     @PropertyName("Terminal Page")
-    @PropertyDescription("Produce terminal pages (only if \"XWiki convertion\" is enabled)")
+    @PropertyDescription("Produce terminal pages (only if \"XWiki conversion\" is enabled)")
     public boolean isTerminalPages()
     {
         return this.terminalPages;
@@ -265,8 +265,8 @@ public class MediaWikiInputProperties extends XMLInputProperties
      */
     @PropertyName("Only take into account registered namespace")
     @PropertyDescription("The importer automatically generate spaces when it find a namespace."
-        + "By default only officially registered MediaWiki namespace are taken into account."
-        + "If this option is disabled all \":\" bases page title prefixes will be seen as namespace separators.")
+        + " By default only officially registered MediaWiki namespace are taken into account."
+        + " If this option is disabled all \":\" bases page title prefixes will be seen as namespace separators.")
     public boolean isOnlyRegisteredNamespaces()
     {
         return this.onlyRegisteredNamespaces;

--- a/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
+++ b/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
@@ -190,7 +190,7 @@ public class MediaWikiInputProperties extends XMLInputProperties
      * @return if true, the content will be parsed to produce rendering events
      */
     @PropertyName("Produce rendering events for the content")
-    @PropertyDescription("Parse the content to produce rendering events (if the output filter support them)")
+    @PropertyDescription("Parse the content to produce rendering events (if the output filter supports them)")
     public boolean isContentEvents()
     {
         return this.contentEvents;

--- a/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
+++ b/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
@@ -245,7 +245,7 @@ public class MediaWikiInputProperties extends XMLInputProperties
      */
     @PropertyName("Absolute reference")
     @PropertyDescription("Force generating absolute reference in links and images (but without the wiki)."
-        + " Overwise the importer try to generate relative reference as much as possible.")
+        + " Otherwise the importer try to generate relative reference as much as possible.")
     public boolean isAbsoluteReferences()
     {
         return this.absoluteReferences;

--- a/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
+++ b/mediawiki-xml/src/main/java/org/xwiki/contrib/mediawiki/xml/input/MediaWikiInputProperties.java
@@ -286,7 +286,7 @@ public class MediaWikiInputProperties extends XMLInputProperties
      * @since 1.8
      */
     @PropertyName("No table of content")
-    @PropertyDescription("Disable automaticlaly generated tables of content (unless _TOC_ is explicitely used)")
+    @PropertyDescription("Disable automatically generated tables of content (unless _TOC_ is explicitely used)")
     public boolean isNoToc()
     {
         return this.noToc;


### PR DESCRIPTION
[Issue link](https://jira.xwiki.org/browse/MEDIAWIKI-97)
Just corrections of a few typing and grammar mistakes.

Before:
![MediaWikiSyntaxBefore](https://user-images.githubusercontent.com/33906649/77233095-fff27d80-6bc6-11ea-81f4-8b37caf74c16.png)
![MediaWikiXML1Before](https://user-images.githubusercontent.com/33906649/77233121-287a7780-6bc7-11ea-94ad-286ea1595bee.png)
![MediaWikiXML2Before](https://user-images.githubusercontent.com/33906649/77233119-27494a80-6bc7-11ea-8f41-6bfbd5ad5f93.png)


After:
![MediaWikiSyntaxAfter](https://user-images.githubusercontent.com/33906649/77233125-303a1c00-6bc7-11ea-898a-d32c6acebc5d.png)
![MediaWikiXML1After](https://user-images.githubusercontent.com/33906649/77233127-34fed000-6bc7-11ea-9467-f95390361e95.png)
![MediaWikiXML2After](https://user-images.githubusercontent.com/33906649/77233128-362ffd00-6bc7-11ea-8969-ca7aac97ae2b.png)

Let me know any problems with this.
Thanks!